### PR TITLE
fix: Handle empty HTML response to prevent API error

### DIFF
--- a/index.html
+++ b/index.html
@@ -348,6 +348,12 @@
                         const doc = parser.parseFromString(siteHtml, 'text/html');
                         const menuContainerEl = doc.querySelector('.c-menu__content');
                         const relevantHtml = menuContainerEl ? menuContainerEl.innerHTML : siteHtml;
+
+                        if (!relevantHtml || !relevantHtml.trim()) {
+                            displayError("Menu content is empty or could not be loaded from the source website. The website might be down or has changed its structure.");
+                            return;
+                        }
+
                         parsedMenuData = await parseMenuWithGemini(relevantHtml, GEMINI_API_KEY);
                         if (parsedMenuData) {
                             saveMenuToCache(parsedMenuData); // Save the new data to cache


### PR DESCRIPTION
Adds a check to validate that the fetched HTML content is not empty before passing it to the Gemini API for parsing. If the content is empty, it displays an error message to the user.

This prevents a 400 Bad Request error from the API when the external menu website returns an empty response.