### PR TITLE
feat: Add preference on Enter key press

### DIFF
--- a/index.html
+++ b/index.html
@@ -419,6 +419,13 @@
                 }
             });
 
+            newKeywordInput.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter') {
+                    e.preventDefault();
+                    addKeywordBtn.click();
+                }
+            });
+
             keywordsContainer.addEventListener('click', (e) => {
                 const deleteBtn = e.target.closest('.delete-keyword-btn');
                 if (deleteBtn) {


### PR DESCRIPTION
Implement functionality to allow adding a new preference by pressing the 'Enter' key in the input field.

This change adds a 'keydown' event listener to the new preference input field. When the 'Enter' key is detected, it triggers the same action as clicking the 'ADD' button, improving user experience and accessibility.