### PR TITLE
Fix: Display menus for all HUBs

### DIFF
--- a/index.html
+++ b/index.html
@@ -255,7 +255,13 @@
             }
 
             async function parseMenuWithGemini(siteHtml, apiKey) {
-                const prompt = `You are a menu parsing assistant. Analyze the provided HTML and extract the weekly menu. Return a single JSON object with keys "HUB 1", "HUB 2", "HUB 3", and "Foodcore". For "HUB 1", "HUB 2", and "HUB 3", the value should be an object mapping each day ("Mandag" to "Fredag") to its dish. "HUB 1" is the first main column, "HUB 2" is the second, and "HUB 3" is the "Kays" menu. For "Foodcore", the value should be an object mapping each day to another object containing "Globetrotter" and "Homebound" dishes. Here is the HTML: --- ${siteHtml} ---`;
+                const prompt = `You are a menu parsing assistant. Analyze the provided HTML and extract the weekly menu. The menu is separated into sections: "HUB 1 – Kays", "HUB 2", "HUB 3", and "Food Court". Return a single JSON object with keys "HUB 1", "HUB 2", "HUB 3", and "Foodcore".
+- For "HUB 1", "HUB 2", and "HUB 3", the value should be an object mapping each day ("Mandag" to "Fredag") to its dish. If a day has a "Vegetar" option, include it in the dish description.
+- "HUB 1" corresponds to the "HUB 1 – Kays" section.
+- "HUB 2" corresponds to the "HUB 2" section.
+- "HUB 3" corresponds to the "HUB 3" section.
+- For "Foodcore", the value should be an object mapping each day to another object containing "Globetrotter" and "Homebound" dishes. The "Food Court" section contains this information.
+Here is the HTML: --- ${siteHtml} ---`;
                 return await callGemini(prompt, apiKey);
             }
 
@@ -386,8 +392,7 @@
                         }
                         const parser = new DOMParser();
                         const doc = parser.parseFromString(siteHtml, 'text/html');
-                        const menuContainerEl = doc.querySelector('.c-menu__content');
-                        const relevantHtml = menuContainerEl ? menuContainerEl.innerHTML : siteHtml;
+                        const relevantHtml = doc.body.innerHTML;
                         parsedMenuData = await parseMenuWithGemini(relevantHtml, GEMINI_API_KEY);
                         if (parsedMenuData) {
                             saveMenuToCache(parsedMenuData);


### PR DESCRIPTION
The "Get Menu & Recommendations" feature was only showing the menu for "HUB 1". This was because the HTML selector used to extract the menu content was too restrictive and only selected the "HUB 1" menu.

This commit fixes the issue by:
- Removing the restrictive HTML selector and using the entire HTML body instead.
- Updating the Gemini API prompt to be more robust and explicitly look for all HUB sections.

These changes ensure that all menus from the scraped website are correctly parsed and displayed in the application.